### PR TITLE
Fix #32 a different way

### DIFF
--- a/Build Systems/Elm Make.sublime-build
+++ b/Build Systems/Elm Make.sublime-build
@@ -6,12 +6,13 @@
     "file_regex": "(?i)^={4} \\w+ in (.+?):(\\d+):(\\d+): ={4}$",
     "syntax": "Packages/Elm Language Support/Syntaxes/Elm Compile Messages.hidden-tmLanguage",
     "color_scheme": "Packages/Color Scheme - Default/Sunburst.tmTheme",
+    "null_device": "/dev/null"
     "working_dir": "$project_path",
     "cmd":
     [
         "elm-make",
         "$file",
-        "--output=/dev/null",
+        "--output=$null",
         "--report=json",
         "--yes"
     ],
@@ -25,14 +26,7 @@
     },
     "windows":
     {
-        "cmd":
-        [
-            "elm-make",
-            "$file",
-            "--output=NUL",
-            "--report=json",
-            "--yes"
-        ]
+        "null_device": "NUL"
     },
     "variants":
     [
@@ -42,13 +36,10 @@
             [
                 "elm-make",
                 "$file",
-                "--output={0}",
+                "--output=$output",
                 "--report=json",
                 "--yes"
-            ],
-            "windows":
-            {
-            }
+            ]
         }
     ]
 }

--- a/Build Systems/Elm Make.sublime-build
+++ b/Build Systems/Elm Make.sublime-build
@@ -1,13 +1,6 @@
 {
     "target": "elm_make",
     "selector": "source.elm",
-    "info_format": "=== $info ===",
-    "error_format": "==== $type in $file:$line:$column: ====\n$message\n----",
-    "file_regex": "(?i)^={4} \\w+ in (.+?):(\\d+):(\\d+): ={4}$",
-    "syntax": "Packages/Elm Language Support/Syntaxes/Elm Compile Messages.hidden-tmLanguage",
-    "color_scheme": "Packages/Color Scheme - Default/Sunburst.tmTheme",
-    "null_device": "/dev/null"
-    "working_dir": "$project_path",
     "cmd":
     [
         "elm-make",
@@ -16,6 +9,17 @@
         "--report=json",
         "--yes"
     ],
+    "working_dir": "$project_path",
+    "file_regex": "(?i)^={4} \\w+ in (.+?):(\\d+):(\\d+): ={4}$",
+    "error_format": "==== $type in $file:$line:$column: ====\n$message\n----",
+    "info_format": "=== $info ===",
+    "syntax": "Packages/Elm Language Support/Syntaxes/Elm Compile Messages.hidden-tmLanguage",
+    "color_scheme": "Packages/Color Scheme - Default/Sunburst.tmTheme",
+    "null_device": "/dev/null"
+    "windows":
+    {
+        "null_device": "NUL"
+    },
     "osx":
     {
         "path": "/usr/local/bin:$PATH"
@@ -23,10 +27,6 @@
     "linux":
     {
         "path": "$HOME/.cabal/bin:/usr/local/bin:$PATH"
-    },
-    "windows":
-    {
-        "null_device": "NUL"
     },
     "variants":
     [

--- a/elm_make.py
+++ b/elm_make.py
@@ -14,18 +14,19 @@ default_exec = import_module('Default.exec')
 class ElmMakeCommand(default_exec.ExecCommand):
 
     # inspired by: http://www.sublimetext.com/forum/viewtopic.php?t=12028
-    def run(self, info_format, error_format, syntax, color_scheme, **kwargs):
+    def run(self, info_format, error_format, syntax, color_scheme, null_device, **kwargs):
         self.buffer = b''
         self.info_format = string.Template(info_format)
         self.error_format = string.Template(error_format)
-        self.do_run(**kwargs)
+        self.do_run(null_device=null_device, **kwargs)
         self.style_output(syntax, color_scheme)
 
-    def do_run(self, cmd, working_dir, **kwargs):
+    def do_run(self, cmd, working_dir, null_device, **kwargs):
         project = ElmProject(cmd[1])
         log_string('project.logging.settings', repr(project))
         cmd[1] = fs.expanduser(project.main_path)
-        cmd[2] = cmd[2].format(fs.expanduser(project.output_path))
+        output_path = fs.expanduser(project.output_path)
+        cmd[2] = string.Template(cmd[2]).substitute(null=null_device, output=output_path)
         project_dir = project.working_dir or working_dir
         # ST2: TypeError: __init__() got an unexpected keyword argument 'syntax'
         super(ElmMakeCommand, self).run(cmd, working_dir=project_dir, **kwargs)

--- a/elm_make.py
+++ b/elm_make.py
@@ -14,10 +14,10 @@ default_exec = import_module('Default.exec')
 class ElmMakeCommand(default_exec.ExecCommand):
 
     # inspired by: http://www.sublimetext.com/forum/viewtopic.php?t=12028
-    def run(self, info_format, error_format, syntax, color_scheme, null_device, **kwargs):
+    def run(self, error_format, info_format, syntax, color_scheme, null_device, **kwargs):
         self.buffer = b''
-        self.info_format = string.Template(info_format)
         self.error_format = string.Template(error_format)
+        self.info_format = string.Template(info_format)
         self.do_run(null_device=null_device, **kwargs)
         self.style_output(syntax, color_scheme)
 


### PR DESCRIPTION
Overriding cmd on Windows cascades to variants. Also unify Python template syntax in buildfile.