### PR TITLE
Colorize delimiters

### DIFF
--- a/Syntaxes/Elm.YAML-tmLanguage
+++ b/Syntaxes/Elm.YAML-tmLanguage
@@ -39,8 +39,6 @@ patterns:
   patterns:
   - name: keyword.import.elm
     match: (as|exposing)
-  - name: keyword.import.elm
-    match: \(\.\.\)
   - include: '#module_name'
   - include: '#module_exports'
 

--- a/Syntaxes/Elm.YAML-tmLanguage
+++ b/Syntaxes/Elm.YAML-tmLanguage
@@ -14,9 +14,6 @@ patterns:
 - name: constant.language.unit.elm
   match: \(\)
 
-- name: constant.language.empty-list.elm
-  match: \[\]
-
 - name: meta.declaration.module.elm
   begin: ^\b(module)\s+
   beginCaptures:

--- a/Syntaxes/Elm.YAML-tmLanguage
+++ b/Syntaxes/Elm.YAML-tmLanguage
@@ -38,7 +38,7 @@ patterns:
   end: ($|;)
   patterns:
   - name: keyword.import.elm
-    match: (as)
+    match: (as|exposing)
   - name: keyword.import.elm
     match: \(\.\.\)
   - include: '#module_name'

--- a/Syntaxes/Elm.YAML-tmLanguage
+++ b/Syntaxes/Elm.YAML-tmLanguage
@@ -127,8 +127,18 @@ patterns:
 - name: keyword.operator.elm
   match: '[|!%$?~+:\-.=</>&\\*^]+'
 
-- name: punctuation.separator.comma.elm
-  match: ','
+# Note: Sublime color schemes consistently decline to apply colors to
+# delimiters of literals. This does Elm users a disservice since
+# Elm's function application syntax thrives on a clear visual distinction
+# between literal delimiters and expressions.
+# We therefore go out of our way to make sure delimiters are colorized.
+- name: constant.language.delimiter.elm
+  match: '([\[\]\{\},])'
+  captures:
+    '1': {name: support.function.delimiter.elm}
+
+- name: keyword.other.parenthesis.elm
+  match: '([\(\)])'
 
 repository:
   block_comment:

--- a/Syntaxes/Elm.YAML-tmLanguage
+++ b/Syntaxes/Elm.YAML-tmLanguage
@@ -1,0 +1,199 @@
+# [PackageDev] target_format: plist, ext: tmLanguage
+name: Elm
+scopeName: source.elm
+fileTypes: [elm]
+uuid: 2cb90e5e-6e98-456d-9a8a-b59935dbc4b0
+
+patterns:
+- name: keyword.operator.function.infix.elm
+  match: (`)[a-zA-Z_']*?(`)
+  captures:
+    '1': {name: punctuation.definition.entity.elm}
+    '2': {name: punctuation.definition.entity.elm}
+
+- name: constant.language.unit.elm
+  match: \(\)
+
+- name: constant.language.empty-list.elm
+  match: \[\]
+
+- name: meta.declaration.module.elm
+  begin: ^\b(module)\s+
+  beginCaptures:
+    '1': {name: keyword.other.elm}
+  end: \b(where)\b
+  endCaptures:
+    '1': {name: keyword.other.elm}
+  patterns:
+  - include: '#module_name'
+  - include: '#module_exports'
+  - name: invalid
+    match: '[a-z]+'
+
+- name: meta.import.elm
+  begin: ^\b(import)\s+((open)\s+)?
+  beginCaptures:
+    '1': {name: keyword.other.elm}
+    '3': {name: invalid}
+  end: ($|;)
+  patterns:
+  - name: keyword.import.elm
+    match: (as)
+  - name: keyword.import.elm
+    match: \(\.\.\)
+  - include: '#module_name'
+  - include: '#module_exports'
+
+- name: entity.glsl.elm
+  begin: (\[)(glsl)(\|)
+  beginCaptures:
+    '1': {name: keyword.other.elm}
+    '2': {name: support.function.prelude.elm}
+    '3': {name: keyword.other.elm}
+  end: (\|\])
+  endCaptures:
+    '1': {name: keyword.other.elm}
+  patterns:
+  - include: source.glsl
+
+- name: keyword.other.elm
+  match: \b(type alias|type|case|of|let|in|as)\s+
+
+- name: keyword.control.elm
+  match: \b(if|then|else)\s+
+
+- comment: Floats are always decimal
+  name: constant.numeric.float.elm
+  match: \b([0-9]+\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\b
+
+- name: constant.numeric.elm
+  match: \b([0-9]+)\b
+
+- name: string.quoted.double.elm
+  begin: '"""'
+  beginCaptures:
+    '0': {name: punctuation.definition.string.begin.elm}
+  end: '"""'
+  endCaptures:
+    '0': {name: punctuation.definition.string.end.elm}
+  patterns:
+  - name: constant.character.escape.elm
+    match: \\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\'\&])
+  - name: constant.character.escape.control.elm
+    match: \^[A-Z@\[\]\\\^_]
+
+- name: string.quoted.double.elm
+  begin: '"'
+  beginCaptures:
+    '0': {name: punctuation.definition.string.begin.elm}
+  end: '"'
+  endCaptures:
+    '0': {name: punctuation.definition.string.end.elm}
+  patterns:
+  - name: constant.character.escape.elm
+    match: \\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\"'\&])
+  - name: constant.character.escape.control.elm
+    match: \^[A-Z@\[\]\\\^_]
+
+- name: string.quoted.single.elm
+  match: "(?x)\n(')\n(?:\n\t[\\ -\\[\\]-~]\t\t\t\t\t\t\t\t# Basic Char\n  | (\\\\\
+    (?:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE\n\t\t|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS\n\
+    \t\t|US|SP|DEL|[abfnrtv\\\\\\\"'\\&]))\t\t# Escapes\n  | (\\^[A-Z@\\[\\]\\\\\\\
+    ^_])\t\t\t\t\t\t# Control Chars\n)\n(')"
+  captures:
+    '1': {name: punctuation.definition.string.begin.elm}
+    '2': {name: constant.character.escape.elm}
+    '3': {name: punctuation.definition.string.end.elm}
+
+- name: meta.function.type-declaration.elm
+  begin: ^(port\s+)?([a-z_][a-zA-Z0-9_']*|\([|!%$+\-.,=</>]+\))\s*((:)([:]+)?)
+  beginCaptures:
+    '1': {name: keyword.other.port.elm}
+    '2': {name: entity.name.function.elm}
+    '4': {name: keyword.other.colon.elm}
+    '5': {name: invalid}
+  end: $\n?
+  patterns:
+  - include: '#type_signature'
+
+- name: keyword.other.port.elm
+  match: \bport\s+
+
+- name: constant.other.elm
+  match: \b[A-Z]\w*\b
+
+- include: '#comments'
+
+- name: entity.name.function.elm
+  match: ^[a-z][A-Za-z0-9_']*\s+
+
+- include: '#infix_op'
+
+- name: keyword.operator.elm
+  match: '[|!%$?~+:\-.=</>&\\*^]+'
+
+- name: punctuation.separator.comma.elm
+  match: ','
+
+repository:
+  block_comment:
+    name: comment.block.elm
+    begin: \{-(?!#)
+    end: -\}
+    captures:
+      '0': {name: punctuation.definition.comment.elm}
+    patterns:
+    - include: '#block_comment'
+    applyEndPatternLast: 1
+
+  comments:
+    patterns:
+    - name: comment.line.double-dash.elm
+      match: (--).*$\n?
+      captures:
+        '1': {name: punctuation.definition.comment.elm}
+    - include: '#block_comment'
+
+  infix_op:
+    name: entity.name.function.infix.elm
+    match: (\([|!%$+:\-.=</>]+\)|\(,+\))
+
+  module_exports:
+    name: meta.declaration.exports.elm
+    begin: \(
+    end: \)
+    patterns:
+    - name: entity.name.function.elm
+      match: \b[a-z][a-zA-Z_'0-9]*
+    - name: storage.type.elm
+      match: \b[A-Z][A-Za-z_'0-9]*
+    - name: punctuation.separator.comma.elm
+      match: ','
+    - include: '#infix_op'
+    - comment: So named because I don't know what to call this.
+      name: meta.other.unknown.elm
+      match: \(.*?\)
+
+  module_name:
+    name: support.other.module.elm
+    match: '[A-Z][A-Za-z._'']*'
+
+  type_signature:
+    patterns:
+    - name: meta.class-constraint.elm
+      match: \(\s*([A-Z][A-Za-z]*)\s+([a-z][A-Za-z_']*)\)\s*(=>)
+      captures:
+        '1': {name: entity.other.inherited-class.elm}
+        '2': {name: variable.other.generic-type.elm}
+        '3': {name: keyword.other.big-arrow.elm}
+    - name: keyword.other.arrow.elm
+      match: ->
+    - name: keyword.other.big-arrow.elm
+      match: =>
+    - name: variable.other.generic-type.elm
+      match: \b[a-z][a-zA-Z0-9_']*\b
+    - name: storage.type.elm
+      match: \b[A-Z][a-zA-Z0-9_']*\b
+    - name: support.constant.unit.elm
+      match: \(\)
+    - include: '#comments'

--- a/Syntaxes/Elm.tmLanguage
+++ b/Syntaxes/Elm.tmLanguage
@@ -36,12 +36,6 @@
 			<string>constant.language.unit.elm</string>
 		</dict>
 		<dict>
-			<key>match</key>
-			<string>\[\]</string>
-			<key>name</key>
-			<string>constant.language.empty-list.elm</string>
-		</dict>
-		<dict>
 			<key>begin</key>
 			<string>^\b(module)\s+</string>
 			<key>beginCaptures</key>

--- a/Syntaxes/Elm.tmLanguage
+++ b/Syntaxes/Elm.tmLanguage
@@ -363,10 +363,24 @@
 			<string>keyword.operator.elm</string>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>support.function.delimiter.elm</string>
+				</dict>
+			</dict>
 			<key>match</key>
-			<string>,</string>
+			<string>([\[\]\{\},])</string>
 			<key>name</key>
-			<string>punctuation.separator.comma.elm</string>
+			<string>constant.language.delimiter.elm</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>([\(\)])</string>
+			<key>name</key>
+			<string>keyword.other.parenthesis.elm</string>
 		</dict>
 	</array>
 	<key>repository</key>

--- a/Syntaxes/Elm.tmLanguage
+++ b/Syntaxes/Elm.tmLanguage
@@ -111,12 +111,6 @@
 					<string>keyword.import.elm</string>
 				</dict>
 				<dict>
-					<key>match</key>
-					<string>\(\.\.\)</string>
-					<key>name</key>
-					<string>keyword.import.elm</string>
-				</dict>
-				<dict>
 					<key>include</key>
 					<string>#module_name</string>
 				</dict>

--- a/Syntaxes/Elm.tmLanguage
+++ b/Syntaxes/Elm.tmLanguage
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>fileTypes</key>
+	<key>fileTypes</key>
 	<array>
 		<string>elm</string>
 	</array>
@@ -106,7 +106,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(as)</string>
+					<string>(as|exposing)</string>
 					<key>name</key>
 					<string>keyword.import.elm</string>
 				</dict>
@@ -292,16 +292,15 @@
 			</dict>
 			<key>match</key>
 			<string>(?x)
-			(')
-			(?:
-				[\ -\[\]-~]								# Basic Char
-			  | (\\(?:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE
-					|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS
-					|US|SP|DEL|[abfnrtv\\\"'\&amp;]))		# Escapes
-			  | (\^[A-Z@\[\]\\\^_])						# Control Chars
-			)
-			(')
-			</string>
+(')
+(?:
+	[\ -\[\]-~]								# Basic Char
+  | (\\(?:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE
+		|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS
+		|US|SP|DEL|[abfnrtv\\\"'\&amp;]))		# Escapes
+  | (\^[A-Z@\[\]\\\^_])						# Control Chars
+)
+(')</string>
 			<key>name</key>
 			<string>string.quoted.single.elm</string>
 		</dict>


### PR DESCRIPTION
This makes commas and braces appear as a different color from the main text, so it's easier to visually distinguish logic from delimiters.

**Note:** this is rebased onto https://github.com/deadfoxygrandpa/Elm.tmLanguage/pull/43#issuecomment-136621704 and includes those changes as well.

## BEFORE: Screenshots without this colorizing
<img width="466" alt="screen shot 2015-09-01 at 9 13 28 am" src="https://cloud.githubusercontent.com/assets/1094080/9609654/baef75ba-5089-11e5-8f56-5107be353564.png">
<img width="466" alt="screen shot 2015-09-01 at 9 12 31 am" src="https://cloud.githubusercontent.com/assets/1094080/9609653/baed02da-5089-11e5-92ad-076bab3a0b14.png">


## AFTER: Screenshots with this colorizing
<img width="475" alt="screen shot 2015-09-01 at 9 06 11 am" src="https://cloud.githubusercontent.com/assets/1094080/9609534/f5d9951c-5088-11e5-8c33-724ba9d0df94.png">
<img width="472" alt="screen shot 2015-09-01 at 9 06 54 am" src="https://cloud.githubusercontent.com/assets/1094080/9609531/f403c42e-5088-11e5-82ea-22e733d9be54.png">
<img width="496" alt="screen shot 2015-09-01 at 9 06 38 am" src="https://cloud.githubusercontent.com/assets/1094080/9609530/f4030930-5088-11e5-9c9e-3fb29603fba1.png">
<img width="471" alt="screen shot 2015-09-01 at 9 07 04 am" src="https://cloud.githubusercontent.com/assets/1094080/9609529/f402c2b8-5088-11e5-811a-da6aca11737a.png">
<img width="466" alt="screen shot 2015-09-01 at 9 09 58 am" src="https://cloud.githubusercontent.com/assets/1094080/9609570/3e6ab3a6-5089-11e5-99c3-9529f9746fa0.png">