### PR TITLE
Run elm-format on Save by default

### DIFF
--- a/Settings/Elm Language Support.sublime-settings
+++ b/Settings/Elm Language Support.sublime-settings
@@ -2,6 +2,6 @@
     "debug": false,
 	"enabled": true,
 	"elm_docs_path": "docs.json",
-	"elm_format_on_save": false,
+	"elm_format_on_save": true,
 	"elm_format_filename_filter": "",
 }


### PR DESCRIPTION
In my experience, if you have elm-format installed, the default use case is that you want it to run on Save - since that's the whole point!

I'd definitely like that to be the default behavior, to save me the trouble of configuring it - naturally, with the option to disable it (or, more likely, add a regexp filter specific to my development environment) if I don't want that default.