### PR TITLE
Fix column num integration w/ HighlightBuildErrors

### DIFF
--- a/Build Systems/Elm Make.sublime-build
+++ b/Build Systems/Elm Make.sublime-build
@@ -10,7 +10,7 @@
         "--yes"
     ],
     "working_dir": "$project_path",
-    "file_regex": "(?i)^={4} \\w+ in (.+?):(\\d+):(\\d+): ={4}$",
+    "file_regex": "(?i)^={4} \\w+ in (.+?):(\\d+):(\\d+): ={4}\\n((?:.|\\n)*?)\\n?-{4}$",
     "error_format": "==== $type in $file:$line:$column: ====\n$message\n----",
     "info_format": "=== $info ===",
     "syntax": "Packages/Elm Language Support/Syntaxes/Elm Compile Messages.hidden-tmLanguage",


### PR DESCRIPTION
Hello,

This PR fixes #93 by capturing the build error message.

Now, the caption displayed under the build error highlight is not the "column number" but the actual build error which is always the first line of the error message.

Before, the column information wasn't compatible with HBE as HBE will only use the column information if the capture group length is >= 4.

![screenshot from 2016-02-25 17 34 24](https://cloud.githubusercontent.com/assets/2097812/13312414/3a6047a6-dbe6-11e5-8cc2-9b8304a9ed89.png)

<s>TODO:
It seems that Sublime Text 3's popup allows for HTML inside the popups, so multiline error message popups are possible. I'll add a fifth capture group with the additional messages in this PR.</s>

<b>Status: Complete, ready to be merged!</b>
