### PR TITLE
Amend grammar to accept Elm 0.17 module declaration

### DIFF
--- a/Syntaxes/Elm.YAML-tmLanguage
+++ b/Syntaxes/Elm.YAML-tmLanguage
@@ -15,15 +15,26 @@ patterns:
   match: \(\)
 
 - name: meta.declaration.module.elm
-  begin: ^\b(module)\s+
+  begin: ^\b((effect|port)\s+)?(module)\s+
   beginCaptures:
     '1': {name: keyword.other.elm}
-  end: \b(where)\b
+    '3': {name: keyword.other.elm}
+  end: $|;
   endCaptures:
     '1': {name: keyword.other.elm}
   patterns:
   - include: '#module_name'
+  - begin: (where)\s*\{
+    beginCaptures:
+      '1': {name: keyword.other.elm}
+    end: \}
+    patterns:
+    - include: '#type_signature'
+  - name: keyword.other.elm
+    match: (exposing)
   - include: '#module_exports'
+  - name: keyword.other.elm
+    match: (where)
   - name: invalid
     match: '[a-z]+'
 

--- a/Syntaxes/Elm.tmLanguage
+++ b/Syntaxes/Elm.tmLanguage
@@ -47,7 +47,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>\b(where)\b</string>
+			<string>\b(where)\b|$|;</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -63,6 +63,12 @@
 				<dict>
 					<key>include</key>
 					<string>#module_name</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(exposing)</string>
+					<key>name</key>
+					<string>keyword.other.elm</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/Syntaxes/Elm.tmLanguage
+++ b/Syntaxes/Elm.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
@@ -37,7 +37,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^\b(module)\s+</string>
+			<string>^\b((effect|port)\s+)?(module)\s+</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -45,9 +45,14 @@
 					<key>name</key>
 					<string>keyword.other.elm</string>
 				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.elm</string>
+				</dict>
 			</dict>
 			<key>end</key>
-			<string>\b(where)\b|$|;</string>
+			<string>$|;</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -65,6 +70,27 @@
 					<string>#module_name</string>
 				</dict>
 				<dict>
+					<key>begin</key>
+					<string>(where)\s*\{</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.elm</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\}</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#type_signature</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
 					<key>match</key>
 					<string>(exposing)</string>
 					<key>name</key>
@@ -73,6 +99,12 @@
 				<dict>
 					<key>include</key>
 					<string>#module_exports</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(where)</string>
+					<key>name</key>
+					<string>keyword.other.elm</string>
 				</dict>
 				<dict>
 					<key>match</key>


### PR DESCRIPTION
Grammar now accepts both syntax variations:

Elm 0.16: `module Queue (..) where`
Elm 0.17: `module Queue exposing (..)`
