### PR TITLE
Adds support for new 0.17 module syntax

### DIFF
--- a/Syntaxes/Elm.YAML-tmLanguage
+++ b/Syntaxes/Elm.YAML-tmLanguage
@@ -18,7 +18,7 @@ patterns:
   begin: ^\b(module)\s+
   beginCaptures:
     '1': {name: keyword.other.elm}
-  end: \b(where)\b
+  end: ($|;)
   endCaptures:
     '1': {name: keyword.other.elm}
   patterns:

--- a/Syntaxes/Elm.tmLanguage
+++ b/Syntaxes/Elm.tmLanguage
@@ -47,7 +47,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>\b(where)\b</string>
+			<string>($|;)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Hi,

I was using Elm 0.17 this morning and the syntax has changed for module declarations which has broken the syntax highlighting in the Sublime package.

I've added what I think fixes the issue but I haven't actually played around with the syntax files for Sublime/Textmate before so might be wrong, but it is highlighting correctly now in Sublime 3 at least.

New syntax:

``` elm
module Module exposing (..)
```

More details here: https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.17.md#updating-syntax

Cheers,

James
